### PR TITLE
fix(T5): fix articles and search improvmeents on wordpress edit page

### DIFF
--- a/wp-content/themes/kotlinskidev/functions/enqueue-scripts.php
+++ b/wp-content/themes/kotlinskidev/functions/enqueue-scripts.php
@@ -45,7 +45,8 @@ function preload_critical_css()
 add_action('wp_head', 'preload_critical_css', 1);
 
 // Enqueue styles for the block editor (Gutenberg)
-function kotlinskidev_editor_styles() {
+function kotlinskidev_editor_styles()
+{
     // Load the same styles in the editor as on the frontend
     wp_enqueue_style(
         'kotlinskidev-editor-style',
@@ -53,7 +54,7 @@ function kotlinskidev_editor_styles() {
         array(),
         wp_get_theme()->get('Version')
     );
-    
+
     // Also load critical CSS in editor
     wp_enqueue_style(
         'kotlinskidev-editor-critical',
@@ -61,7 +62,7 @@ function kotlinskidev_editor_styles() {
         array(),
         wp_get_theme()->get('Version')
     );
-    
+
     // Load Tailwind CSS in editor
     wp_enqueue_style(
         'kotlinskidev-editor-tailwind',
@@ -69,5 +70,59 @@ function kotlinskidev_editor_styles() {
         array(),
         wp_get_theme()->get('Version')
     );
+
+    // Load Editor overrides CSS in editor
+    wp_enqueue_style(
+        'kotlinskidev-editor-overrides',
+        get_template_directory_uri() . '/build/editor.css',
+        array(),
+        wp_get_theme()->get('Version')
+    );
+
+    // Load banner carousel
+    wp_enqueue_style(
+        'kotlinskidev-banner-carousel-styles',
+        get_template_directory_uri() . '/build/banner-carousel.css',
+        array(),
+        wp_get_theme()->get('Version')
+    );
 }
-add_action('enqueue_block_editor_assets', 'kotlinskidev_editor_styles');
+function kotlinskidev_editor_scripts()
+{
+    // Load the main JavaScript file in editor (includes scroll animations)
+    wp_enqueue_script(
+        'kotlinskidev-editor-index-js',
+        get_template_directory_uri() . '/build/main.js',
+        array(),
+        wp_get_theme()->get('Version'),
+        true
+    );
+
+    // Load critical JavaScript file in editor
+    wp_enqueue_script(
+        'kotlinskidev-editor-critical-js',
+        get_template_directory_uri() . '/build/critical.js',
+        array(),
+        wp_get_theme()->get('Version'),
+        true
+    );
+
+    // Load editor-only functionality (scroll animation controls)
+    wp_enqueue_script(
+        'kotlinskidev-editor-only',
+        get_template_directory_uri() . '/build/editor.js',
+        array(),
+        wp_get_theme()->get('Version'),
+        true
+    );
+
+    // Load banner carousel
+    wp_enqueue_script(
+        'kotlinskidev-banner-carousel',
+        get_template_directory_uri() . '/build/banner-carousel.js',
+        array(),
+        wp_get_theme()->get('Version'),
+        true
+    );
+}
+add_action('enqueue_block_editor_assets', 'kotlinskidev_editor_styles', 'kotlinskidev_editor_scripts');

--- a/wp-content/themes/kotlinskidev/patterns/search-results.php
+++ b/wp-content/themes/kotlinskidev/patterns/search-results.php
@@ -89,7 +89,7 @@ if (!empty($search_query)) :
                     <a href="<?php the_permalink(); ?>">
                         <img src="<?php the_post_thumbnail_url('medium'); ?>" 
                              alt="<?php the_title(); ?>" 
-                             style="width:150px;height:100px;object-fit:cover;border-radius:12px;" />
+                             style="width:200px;height:200px;object-fit:contain;border-radius:12px;" />
                     </a>
                 </div>
                 <?php endif; ?>

--- a/wp-content/themes/kotlinskidev/src/blocks/scroll-animations/index.tsx
+++ b/wp-content/themes/kotlinskidev/src/blocks/scroll-animations/index.tsx
@@ -1,0 +1,117 @@
+import { __ } from '@wordpress/i18n';
+import { addFilter } from '@wordpress/hooks';
+import { Fragment } from '@wordpress/element';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, SelectControl } from '@wordpress/components';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import React from 'react';
+
+// Define available scroll animations
+const scrollAnimations = [
+    { label: __('No Animation', 'kotlinskidev'), value: '' },
+    { label: __('Fade In', 'kotlinskidev'), value: 'fade-in-on-scroll' },
+    { label: __('Fade Up', 'kotlinskidev'), value: 'fade-up-on-scroll' },
+    { label: __('Fade Left', 'kotlinskidev'), value: 'fade-left-on-scroll' },
+    { label: __('Fade Right', 'kotlinskidev'), value: 'fade-right-on-scroll' },
+];
+
+// Add scroll animation attribute to all blocks
+function addScrollAnimationAttribute(settings: any) {
+    // Skip for certain core blocks that shouldn't have animations
+    const excludedBlocks = [
+        'core/html',
+        'core/code',
+        'core/preformatted',
+        'core/verse'
+    ];
+
+    if (excludedBlocks.includes(settings.name)) {
+        return settings;
+    }
+
+    // Add our custom attribute
+    if (typeof settings.attributes !== 'undefined') {
+        settings.attributes = {
+            ...settings.attributes,
+            scrollAnimation: {
+                type: 'string',
+                default: ''
+            }
+        };
+    }
+
+    return settings;
+}
+
+// Add animation controls to block inspector
+const withScrollAnimationControls = createHigherOrderComponent((BlockEdit) => {
+    return (props: any) => {
+        const { attributes, setAttributes, name } = props;
+        const { scrollAnimation } = attributes;
+
+        // Skip for certain blocks
+        const excludedBlocks = [
+            'core/html',
+            'core/code',
+            'core/preformatted',
+            'core/verse'
+        ];
+
+        if (excludedBlocks.includes(name)) {
+            return <BlockEdit {...props} />;
+        }
+
+        return (
+            <Fragment>
+                <BlockEdit {...props} />
+                <InspectorControls>
+                    <PanelBody
+                        title={__('Scroll Animations', 'kotlinskidev')}
+                        icon="art"
+                        initialOpen={false}
+                    >
+                        <SelectControl
+                            label={__('Animation Type', 'kotlinskidev')}
+                            value={scrollAnimation || ''}
+                            options={scrollAnimations}
+                            onChange={(value: string) => setAttributes({ scrollAnimation: value })}
+                            help={__('Choose an animation that will trigger when the block comes into view.', 'kotlinskidev')}
+                        />
+                    </PanelBody>
+                </InspectorControls>
+            </Fragment>
+        );
+    };
+}, 'withScrollAnimationControls');
+
+// Apply animation class to block wrapper
+function applyScrollAnimationClass(extraProps: any, blockType: any, attributes: any) {
+    const { scrollAnimation } = attributes;
+    
+    if (scrollAnimation) {
+        extraProps.className = extraProps.className 
+            ? `${extraProps.className} ${scrollAnimation}` 
+            : scrollAnimation;
+    }
+    
+    return extraProps;
+}
+
+// Register the filters
+addFilter(
+    'blocks.registerBlockType',
+    'kotlinskidev/scroll-animation-attribute',
+    addScrollAnimationAttribute
+);
+
+addFilter(
+    'editor.BlockEdit',
+    'kotlinskidev/scroll-animation-controls',
+    withScrollAnimationControls
+);
+
+addFilter(
+    'blocks.getSaveContent.extraProps',
+    'kotlinskidev/scroll-animation-class',
+    applyScrollAnimationClass
+);

--- a/wp-content/themes/kotlinskidev/src/editor.ts
+++ b/wp-content/themes/kotlinskidev/src/editor.ts
@@ -1,0 +1,3 @@
+// Editor-only functionality - this file is only loaded in the WordPress block editor
+import './styles/editor-overrides.scss';
+import './blocks/scroll-animations';

--- a/wp-content/themes/kotlinskidev/src/styles/editor-overrides.scss
+++ b/wp-content/themes/kotlinskidev/src/styles/editor-overrides.scss
@@ -1,0 +1,57 @@
+// Editor-only styles to override scroll animations
+// This ensures all content is visible in the WordPress block editor
+
+.block-editor-block-list__layout,
+.wp-block-editor,
+.editor-styles-wrapper {
+  // Override all scroll animation opacity to make content visible in editor
+  .fade-in-on-scroll,
+  .fade-up-on-scroll,
+  .fade-left-on-scroll,
+  .fade-right-on-scroll {
+    opacity: 1 !important;
+    transform: none !important;
+    transition: none !important;
+  }
+
+  // Also override the visible states to ensure consistency
+  .fade-in-on-scroll.visible,
+  .fade-up-on-scroll.visible,
+  .fade-left-on-scroll.visible,
+  .fade-right-on-scroll.visible {
+    opacity: 1 !important;
+    transform: none !important;
+    transition: none !important;
+  }
+}
+
+// Additional editor-specific overrides for better editing experience
+.block-editor-block-list__block {
+  // Ensure all blocks are fully visible regardless of animation classes
+  &.fade-in-on-scroll,
+  &.fade-up-on-scroll,
+  &.fade-left-on-scroll,
+  &.fade-right-on-scroll {
+    opacity: 1 !important;
+    transform: none !important;
+    transition: none !important;
+  }
+}
+
+// Override for nested blocks and group blocks
+.wp-block-group,
+.wp-block-columns,
+.wp-block-column {
+  .fade-in-on-scroll,
+  .fade-up-on-scroll,
+  .fade-left-on-scroll,
+  .fade-right-on-scroll {
+    opacity: 1 !important;
+    transform: none !important;
+    transition: none !important;
+  }
+}
+
+.swiper{
+    visibility: visible !important;
+}

--- a/wp-content/themes/kotlinskidev/webpack.config.js
+++ b/wp-content/themes/kotlinskidev/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = {
 		main: path.resolve(process.cwd(), 'src', 'index.ts'),
 		critical: path.resolve(process.cwd(), 'src', 'critical.scss'),
 		'banner-carousel': path.resolve(process.cwd(), 'src', 'blocks', 'banner-carousel', 'index.ts'),
+		'editor': path.resolve(process.cwd(), 'src', 'editor.ts'),
 	},
 
 	output: {


### PR DESCRIPTION
fix articles and search improvmeents on wordpress page editor. Added option to pick the animation from dropdown, instead of putting class manually